### PR TITLE
Fix the function that joins base urls and relative / absolute URLs.

### DIFF
--- a/speedparser/speedparser.py
+++ b/speedparser/speedparser.py
@@ -18,6 +18,7 @@ import re
 import os
 import sys
 import time
+import urlparse
 import chardet
 from lxml import etree, html
 from lxml.html import clean
@@ -134,13 +135,7 @@ def base_url(root):
     return None
 
 def full_href(href, base=None):
-    if base is None:
-        return href
-    if href.startswith('javascript:'):
-        return href
-    if 'http://' in href or 'https://' in href:
-        return href
-    return '%s/%s' % (base.rstrip('/'), href.lstrip('/'))
+    return urlparse.urljoin(base, href)
 
 def full_href_attribs(attribs, base=None):
     if base is None: return dict(attribs)


### PR DESCRIPTION
The Python standard version of this function is more capable than the previous
version. The previous version could not join URLs of the form
//www.mydomain.com/foo with the base URL. See a live example of this problem
in the feed http://www.infojobs.net/trabajos.rss/kw_candidate/
