### PR TITLE
Fix attribute error when titles are None (can't call strip on them).

### DIFF
--- a/speedparser/speedparser.py
+++ b/speedparser/speedparser.py
@@ -277,8 +277,9 @@ class SpeedParserEntriesRss20(object):
     def parse_title(self, node, entry, ns=''):
         if ns in ('media',) and 'title' in entry:
             return
-        title = unicoder(node.text).strip() or ''
-        title = strip_outer_tag(self.clean(title))
+        title = unicoder(node.text)
+        if title is not None:
+            title = strip_outer_tag(self.clean(title.strip()))
         entry['title'] = title or ''
 
     def parse_author(self, node, entry, ns=''):


### PR DESCRIPTION
`unicoder()` can return None, and `parse_title` calls `strip()` on its result, assuming it'll always be a string.

This change simply safeguards against the error that can occur here.

An example feed causing this issue is http://www.my01976.com/?feed=rss2
