### PR TITLE
speedparser requires chardet

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
       # -*- Extra requirements: -*-
       # 'feedparser>=0.5',
       'lxml',
+      'chardet',
     ],
     entry_points="""
     # -*- Entry points: -*-


### PR DESCRIPTION
add the 'chardet' requirement since it's necessary.